### PR TITLE
Update to Linux install location

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,9 @@ archive).
 
 ### Linux (per user)
 
-```bash
-cd $PACKET_SIMPLEMESSAGE
-mkdir -p ~/.local/lib/wireshark/plugins
-cp packet-simplemessage.lua ~/.local/lib/wireshark/plugins
-```
+    cd $PACKET_SIMPLEMESSAGE
+    mkdir -p ~/.local/lib/wireshark/plugins
+    cp packet-simplemessage.lua ~/.local/lib/wireshark/plugins
 
 ### Windows (per user)
 

--- a/README.md
+++ b/README.md
@@ -48,9 +48,11 @@ archive).
 
 ### Linux (per user)
 
-    cd $PACKET_SIMPLEMESSAGE
-    mkdir -p ~/.wireshark/plugins
-    cp packet-simplemessage.lua ~/.wireshark/plugins
+```bash
+cd $PACKET_SIMPLEMESSAGE
+mkdir -p ~/.local/lib/wireshark/plugins
+cp packet-simplemessage.lua ~/.local/lib/wireshark/plugins
+```
 
 ### Windows (per user)
 


### PR DESCRIPTION
As shown in #24 the installation instructions are out of date. This PR updates the installation instructions to meet the current Wireshark documentation.